### PR TITLE
Feat(Core): Gradient and dual background support in traits

### DIFF
--- a/packages/core/src/base/components/LayoutComponent.php
+++ b/packages/core/src/base/components/LayoutComponent.php
@@ -11,7 +11,7 @@ abstract class LayoutComponent extends UIComponent {
     public function __construct(array $attributes, array $innerComponents, string $bladeFile) {
         parent::__construct($attributes, $innerComponents, $bladeFile);
         $this->set_layout_alignment($attributes);
-        $this->set_background_color($attributes);
+        $this->set_background_colors($attributes);
         $this->set_is_nested(isset($attributes['isNested']) && (bool)$attributes['isNested']);
 
         if (isset($this->backgroundColor)) {

--- a/packages/core/src/base/components/PanelGroupComponent.php
+++ b/packages/core/src/base/components/PanelGroupComponent.php
@@ -20,7 +20,7 @@ abstract class PanelGroupComponent extends UIComponent {
         parent::__construct($attributes, $innerComponents, $bladeFile);
         $this->prepare_inner_components_for_vue($innerComponents);
         $this->set_color_theme($attributes, ThemeColor::PRIMARY);
-        $this->set_background_color($attributes);
+        $this->set_background_colors($attributes);
         $this->set_orientation($attributes);
         $this->set_is_nested($attributes['isNested'] ?? false);
         $this->set_size($attributes);

--- a/packages/core/src/base/traits/BackgroundColor.php
+++ b/packages/core/src/base/traits/BackgroundColor.php
@@ -3,87 +3,83 @@ namespace Doubleedesign\Comet\Core;
 
 trait BackgroundColor {
     /**
-     * @var ?ThemeColor $backgroundColor
-     * @description Background colour keyword
+     * @var BackgroundCollection|null $backgroundColors
+     * @description Key -> value pairs of background placement and colour keywords
      */
-    protected ?ThemeColor $backgroundColor = null;
+    protected ?BackgroundCollection $backgroundColors = null;
 
     /**
      * @param  array  $attributes
-     * @param  ThemeColor|null  $fallback
      * @description Retrieves the relevant properties from the component $attributes array or component defaults, validates them, and assigns them to the corresponding component instance field.
      */
-    protected function set_background_color(array $attributes, ?ThemeColor $fallback = null): void {
-        // Set from passed-in attributes if set
-        if (isset($attributes['backgroundColor'])) {
-            $this->backgroundColor = $this->get_from_string_or_theme_color($attributes['backgroundColor']);
+    protected function set_background_colors(array $attributes): void {
+        // Backwards compatibility: Allow for 'backgroundColor', but prefer newer backgroundColors
+        $maybeAttr = $attributes['backgroundColors'] ?? $attributes['backgroundColor'] ?? null;
+        if ($maybeAttr !== null) {
+            $this->backgroundColors = $this->transform_to_collection($maybeAttr);
         }
-
         // If no passed-in attribute (or applying it failed), check component defaults
-        if (!$this->backgroundColor) {
+        else {
             $class = static::class;
             $classShortname = Utils::kebab_case(substr($class, strrpos($class, '\\') + 1));
             $defaults = Config::getInstance()->get_component_defaults($classShortname);
-            if (isset($defaults['backgroundColor'])) {
-                $this->backgroundColor = $this->get_from_string_or_theme_color($defaults['backgroundColor']);
+            if (isset($defaults['backgroundColors']) || isset($defaults['backgroundColor'])) {
+                $this->backgroundColors = $this->transform_to_collection($defaults['backgroundColors'] ?? $defaults['backgroundColor']);
             }
         }
 
-        // If still null, use the passed-in fallback if there is one
-        if (!isset($this->backgroundColor) && isset($fallback)) {
-            $this->backgroundColor = $this->get_from_string_or_theme_color($fallback);
-        }
-
-        // Only keep the set background color if this is nested OR the background color is different from the global background
-        // So we don't set background attributes on top-level components when not needed
-        $globalBackground = Config::getInstance()->get_global_background();
-        $isSameAsGlobal = isset($this->backgroundColor) && $this->backgroundColor === $globalBackground;
+        // If the outer background is the same as the global background and this component is not nested,
+        // remove it so we don't set background attributes on top-level components when not needed
         $isNested = (isset($this->isNested) && $this->isNested) || (isset($attributes['isNested']) && $attributes['isNested']);
-        if ((!$isNested && $isSameAsGlobal) || !isset($attributes['backgroundColor'])) {
-            $this->backgroundColor = null;
+        if (!$isNested) {
+            $globalBackground = Config::getInstance()->get_global_background();
+            $isSameAsGlobal = isset($this->backgroundColor->outer) && $this->backgroundColor->outer === $globalBackground;
+            if ($isSameAsGlobal) {
+                $this->backgroundColors = new BackgroundCollection(null, $this->backgroundColors->inner);
+            }
         }
     }
 
-    private function get_from_string_or_theme_color($value): ?ThemeColor {
-        if ($value instanceof ThemeColor) {
-            return $value;
-        }
-        else if (is_string($value)) {
-            return ThemeColor::tryFrom($value);
-        }
-
-        return null;
+    private function transform_to_collection($value): ?BackgroundCollection {
+        // This was extracted out into the collection class for isolated testing and troubleshooting
+        return BackgroundCollection::transform_to_collection($value);
     }
 
     /**
-     * @description Get the background colour of the component.
+     * @description Get the background colours of the component.
      *
-     * @return ?ThemeColor
+     * @return ?BackgroundCollection;
      */
-    public function get_background_color(): ?ThemeColor {
-        return $this->backgroundColor;
+    public function get_background_colors(): ?BackgroundCollection {
+        return $this->backgroundColors;
+    }
+
+    /**
+     * @description Get the background colour of the component; intended for use when only one is expected (primarily for backwards compatibility).
+     *              If both inner and outer background colours are set, this will return the outer colour only.
+     *
+     * @return ThemeColor|ThemeGradient|null
+     */
+    public function get_background_color(): ThemeColor|ThemeGradient|null {
+        if (isset($this->backgroundColors->outer) && isset($this->backgroundColors->inner)) {
+            error_log("Warning:" . static::class . " has both outer and inner background colors set, but you called get_background_colour(), which returns the outer colour only. If this was not intentional, you might want get_background_colours().");
+        }
+
+        return $this->backgroundColors->outer ?? $this->backgroundColors->inner ?? null;
     }
 
     /**
      * @description Allows the background colour of a component to be set based on contextual factors not available at instantiation.
-     * @param  string|null|ThemeColor  $backgroundColor
+     * @param  string|null|ThemeColor  $backgroundColors
      *
      * @return void
      */
-    public function update_background_color(ThemeColor|string|null $backgroundColor): void {
-        if ($backgroundColor instanceof ThemeColor) {
-            $this->backgroundColor = $backgroundColor;
-        }
-        else if (is_string($backgroundColor)) {
-            $this->backgroundColor = ThemeColor::tryFrom($backgroundColor);
-        }
-        else {
-            $this->backgroundColor = null;
-        }
+    public function update_background_color(ThemeColor|string|null $backgroundColors): void {
+        $this->backgroundColors = $this->transform_to_collection($backgroundColors);
     }
 
     /**
-     * @description Clean up duplication of background colours between this and its inner components simplify HTML and CSS. Runs either remove_redundant_background_colors() or set_background_color_based_on_children() as appropriate.
+     * @description Clean up duplication of background colours between this and its inner components simplify HTML and CSS. Runs either remove_redundant_background_colors() or set_background_colors_based_on_children() as appropriate.
      * NOTE: This must be run after the constructor and after update_background_color() to ensure the backgrounds and innerComponents are available
      *
      * @return void
@@ -91,14 +87,14 @@ trait BackgroundColor {
     public function simplify_all_background_colors(): void {
         // If all backgrounds set on direct children of this component are the same as this component's background,
         // remove the background from those children
-        if (isset($this->backgroundColor) && isset($this->innerComponents)) {
+        if (isset($this->backgroundColors->outer) && isset($this->innerComponents)) {
             $this->remove_redundant_background_colors();
         }
 
         // If this component does not have a background set but its children all have the same background and/or no background,
         // remove the backgrounds from the children and apply that singular set background to this component
-        if (!$this->backgroundColor && isset($this->innerComponents)) {
-            $this->set_background_color_based_on_inner_components();
+        if (!$this->backgroundColors && isset($this->innerComponents)) {
+            $this->set_background_colors_based_on_inner_components();
         }
     }
 
@@ -115,8 +111,8 @@ trait BackgroundColor {
         }
 
         $childrenWithSameBackground = array_filter($this->innerComponents, function($child) {
-            if (method_exists($child, 'get_background_color')) {
-                return $child->get_background_color() === $this->backgroundColor;
+            if (method_exists($child, 'get_background_colors')) {
+                return $child->get_background_colors() === $this->backgroundColor;
             }
 
             return false;
@@ -124,8 +120,8 @@ trait BackgroundColor {
 
         if (count($childrenWithSameBackground) > 0) {
             $updatedInnerComponents = array_map(function($child) {
-                if (method_exists($child, 'update_background_color') && method_exists($child, 'get_background_color')) {
-                    if ($child->get_background_color() === $this->backgroundColor) {
+                if (method_exists($child, 'update_background_color') && method_exists($child, 'get_background_colors')) {
+                    if ($child->get_background_colors() === $this->backgroundColor) {
                         $child->update_background_color(null);
                     }
                 }
@@ -143,7 +139,7 @@ trait BackgroundColor {
      *
      * @return void
      */
-    protected function set_background_color_based_on_inner_components(): void {
+    protected function set_background_colors_based_on_inner_components(): void {
         // No need to set the background if it's already set
         if ($this->backgroundColor) {
             return;
@@ -158,9 +154,9 @@ trait BackgroundColor {
         // But do not filter out null values, because that would set the background of a parent when it shouldn't
         // just because *some* children don't have an explicit background
         $childBackgrounds = array_reduce($this->innerComponents, function($carry, $child) {
-            if (method_exists($child, 'get_background_color')) {
-                if (!in_array($child->get_background_color(), $carry)) {
-                    $carry[] = $child->get_background_color();
+            if (method_exists($child, 'get_background_colors')) {
+                if (!in_array($child->get_background_colors(), $carry)) {
+                    $carry[] = $child->get_background_colors();
                 }
             }
 

--- a/packages/core/src/base/traits/__tests__/BackgroundColorTest.php
+++ b/packages/core/src/base/traits/__tests__/BackgroundColorTest.php
@@ -1,5 +1,17 @@
 <?php
-use Doubleedesign\Comet\Core\{BackgroundColor, ThemeColor};
+
+use Doubleedesign\Comet\Core\{BackgroundCollection, Config, BackgroundColor, ThemeColor, ThemeGradient};
+use function Patchwork\{redefine, relay, restoreAll};
+use function Spies\{make_spy, match_array, expect_spy};
+
+beforeEach(function() {
+    Config::init();
+    Config::getInstance()->set_global_background(ThemeColor::WHITE);
+});
+
+afterEach(function() {
+    restoreAll();
+});
 
 /**
  * Function to create a generic component class that uses the trait
@@ -14,11 +26,7 @@ function create_component_with_bg_color(array $attributes): object {
         use BackgroundColor;
 
         public function __construct(array $attributes) {
-            $this->set_background_color($attributes);
-        }
-
-        public function get_background_color() {
-            return $this->backgroundColor;
+            $this->set_background_colors($attributes);
         }
     };
 }
@@ -37,36 +45,99 @@ function create_component_with_inner_components(array $attributes = [], array $i
         public array $innerComponents = [];
 
         public function __construct(array $attributes, array $innerComponents = []) {
-            $this->set_background_color($attributes);
+            $this->set_background_colors($attributes);
             $this->innerComponents = $innerComponents;
         }
     };
 }
 
-describe('Set background color from attributes', function() {
-    $spy = Mockery::spy(BackgroundColor::class);
-    $spy->shouldAllowMockingProtectedMethods();
+// Ensure backwards compatibility with the old attribute name is maintained
+dataset('all valid attribute names', [['backgroundColor'], ['backgroundColors']]);
 
-    test('sets valid value', function() use ($spy) {
-        $component = create_component_with_bg_color(['backgroundColor' => 'secondary']);
+dataset('all valid attribute types (single colour)', [
+    'ThemeColor object'                 => ThemeColor::PRIMARY,
+    'ThemeColor string'                 => 'primary',
+    'Array with single object'          => [ThemeColor::PRIMARY],
+    'Array with single string'          => ['primary'],
+]);
 
-        $spy->shouldReceive('set_background_color');
-        expect($component->get_background_color())->toBe(ThemeColor::SECONDARY);
-    });
+dataset('all valid attribute types (single gradient)', [
+    'ThemeGradient object'              => new ThemeGradient('dark', 'light'),
+    'ThemeGradient string'              => 'dark-light',
+    'Array with single object'          => [new ThemeGradient('dark', 'light')],
+    'Array with single string'          => ['dark-light'],
+]);
 
-    test('sets null when invalid', function() use ($spy) {
-        $component = create_component_with_bg_color(['backgroundColor' => '#FFF']);
+describe('Set value from attributes', function() {
+    it('sets a valid single colour', function(string $attributeName, $value) {
+        $component = create_component_with_bg_color([$attributeName => $value]);
 
-        $spy->shouldReceive('set_background_color');
-        expect($component->get_background_color())->toBeNull();
-    });
+        expect($component->get_background_color())->toEqual(ThemeColor::PRIMARY)
+            ->and($component->get_background_colors()->outer)->toEqual(ThemeColor::PRIMARY);
+    })->with('all valid attribute names')
+        ->with('all valid attribute types (single colour)');
+
+    it('sets a valid single gradient', function(string $attributeName, $value) {
+        $component = create_component_with_bg_color([$attributeName => $value]);
+
+        expect($component->get_background_color())->toEqual(new ThemeGradient('dark', 'light'))
+            ->and($component->get_background_colors()->outer)->toEqual(new ThemeGradient('dark', 'light'));
+    })->with('all valid attribute names')
+        ->with('all valid attribute types (single gradient)');
+
+    it('sets a valid colour pair', function() {
+        $spy = make_spy();
+        redefine('Doubleedesign\Comet\Core\BackgroundCollection::transform_to_collection', function($value) use ($spy) {
+            $spy($value);
+            return relay();
+        });
+
+        $component = create_component_with_bg_color(['backgroundColors' => ['light', 'dark']]);
+
+        expect_spy($spy)->to_have_been_called->with(match_array(['light', 'dark']))->verify();
+        expect($component->get_background_colors())->toBeInstanceOf(BackgroundCollection::class);
+    })->with('all valid attribute names');
 });
 
-describe('Remove redundant background colours from direct inner components', function() {
-    $spy = Mockery::spy(BackgroundColor::class);
-    $spy->shouldAllowMockingProtectedMethods();
+describe('Set value from component defaults', function() {
+    it('sets a valid single colour', function(string $attributeName, $value) {
+        redefine('Doubleedesign\Comet\Core\Config::get_component_defaults', fn() => [$attributeName => $value]);
 
-    test('it removes background when all backgrounds match the component', function() use ($spy) {
+        $component = create_component_with_bg_color([]);
+
+        expect($component->get_background_color())->toEqual(ThemeColor::PRIMARY);
+        expect($component->get_background_colors()->outer)->toEqual(ThemeColor::PRIMARY);
+    })->with('all valid attribute names')
+        ->with('all valid attribute types (single colour)');
+
+    it('sets a valid single gradient', function(string $attributeName, $value) {
+        redefine('Doubleedesign\Comet\Core\Config::get_component_defaults', fn() => [$attributeName => $value]);
+
+        $component = create_component_with_bg_color([]);
+
+        expect($component->get_background_color())->toEqual(new ThemeGradient('dark', 'light'));
+        expect($component->get_background_colors()->outer)->toEqual(new ThemeGradient('dark', 'light'));
+    })->with('all valid attribute names')
+        ->with('all valid attribute types (single gradient)');
+
+    it('sets a valid colour pair', function(string $attributeName) {
+	    redefine('Doubleedesign\Comet\Core\Config::get_component_defaults', fn() => ['backgroundColors' => ['light', 'dark']]);
+        $spy = make_spy();
+        redefine('Doubleedesign\Comet\Core\BackgroundCollection::transform_to_collection', function($value) use ($spy) {
+            $spy($value);
+            return relay();
+        });
+
+        $component = create_component_with_bg_color(['backgroundColors' => ['light', 'dark']]);
+
+        expect_spy($spy)->to_have_been_called->with(match_array(['light', 'dark']))->verify();
+        expect($component->get_background_colors())->toBeInstanceOf(BackgroundCollection::class);
+    })->with('all valid attribute names');
+});
+
+ describe('Remove redundant background colours from direct inner components', function() {
+
+    test('it removes background when all backgrounds match the component', function() {
         $child1 = create_component_with_bg_color(['backgroundColor' => 'primary']);
         $child2 = create_component_with_bg_color(['backgroundColor' => 'primary']);
         $child3 = create_component_with_bg_color(['backgroundColor' => 'primary']);
@@ -78,14 +149,13 @@ describe('Remove redundant background colours from direct inner components', fun
 
         $parent->simplify_all_background_colors();
 
-        $spy->shouldReceive('remove_redundant_background_colors');
-        expect($parent->get_background_color())->toBe(ThemeColor::PRIMARY);
+        expect($parent->get_background_colors())->toBe(ThemeColor::PRIMARY);
         foreach ($parent->innerComponents as $child) {
-            expect($child->get_background_color())->toBeNull();
+            expect($child->get_background_colors())->toBeNull();
         }
     });
 
-    test('it removes only the same background when inner components are mixed', function() use ($spy) {
+    test('it removes only the same background when inner components are mixed', function() {
         $child1 = create_component_with_bg_color(['backgroundColor' => 'primary']);
         $child2 = create_component_with_bg_color(['backgroundColor' => 'secondary']);
         $child3 = create_component_with_bg_color(['backgroundColor' => 'accent']);
@@ -97,14 +167,13 @@ describe('Remove redundant background colours from direct inner components', fun
 
         $parent->simplify_all_background_colors();
 
-        $spy->shouldReceive('remove_redundant_background_colors');
-        expect($parent->get_background_color())->toBe(ThemeColor::PRIMARY)
-            ->and($parent->innerComponents[0]->get_background_color())->toBeNull()
-            ->and($parent->innerComponents[1]->get_background_color())->toBe(ThemeColor::SECONDARY)
-            ->and($parent->innerComponents[2]->get_background_color())->toBe(ThemeColor::ACCENT);
+        expect($parent->get_background_colors())->toBe(ThemeColor::PRIMARY)
+            ->and($parent->innerComponents[0]->get_background_colors())->toBeNull()
+            ->and($parent->innerComponents[1]->get_background_colors())->toBe(ThemeColor::SECONDARY)
+            ->and($parent->innerComponents[2]->get_background_colors())->toBe(ThemeColor::ACCENT);
     });
 
-    test('it does nothing if there is only one inner component', function() use ($spy) {
+    test('it does nothing if there is only one inner component', function() {
         $child1 = create_component_with_bg_color(['backgroundColor' => 'primary']);
 
         $parent = create_component_with_inner_components(
@@ -114,17 +183,13 @@ describe('Remove redundant background colours from direct inner components', fun
 
         $parent->simplify_all_background_colors();
 
-        $spy->shouldNotHaveReceived('remove_redundant_background_colors');
-        expect($parent->get_background_color())->toBe(ThemeColor::PRIMARY)
-            ->and($parent->innerComponents[0]->get_background_color())->toBe(ThemeColor::PRIMARY);
+        expect($parent->get_background_colors())->toBe(ThemeColor::PRIMARY)
+            ->and($parent->innerComponents[0]->get_background_colors())->toBe(ThemeColor::PRIMARY);
     });
-});
+ });
 
-describe('Set background colour based on inner components', function() {
-    $spy = Mockery::spy(BackgroundColor::class);
-    $spy->shouldAllowMockingProtectedMethods();
-
-    test('it sets a background when all inner components have the same background', function() use ($spy) {
+ describe('Set background colour based on inner components', function() {
+    test('it sets a background when all inner components have the same background', function() {
         $child1 = create_component_with_bg_color(['backgroundColor' => 'secondary']);
         $child2 = create_component_with_bg_color(['backgroundColor' => 'secondary']);
         $child3 = create_component_with_bg_color(['backgroundColor' => 'secondary']);
@@ -136,14 +201,13 @@ describe('Set background colour based on inner components', function() {
 
         $parent->simplify_all_background_colors();
 
-        $spy->shouldReceive('set_background_color_based_on_inner_components');
-        expect($parent->get_background_color())->toBe(ThemeColor::SECONDARY)
-            ->and($parent->innerComponents[0]->get_background_color())->toBeNull()
-            ->and($parent->innerComponents[1]->get_background_color())->toBeNull()
-            ->and($parent->innerComponents[2]->get_background_color())->toBeNull();
+        expect($parent->get_background_colors())->toBe(ThemeColor::SECONDARY)
+            ->and($parent->innerComponents[0]->get_background_colors())->toBeNull()
+            ->and($parent->innerComponents[1]->get_background_colors())->toBeNull()
+            ->and($parent->innerComponents[2]->get_background_colors())->toBeNull();
     });
 
-    test('it does nothing when children have different backgrounds', function() use ($spy) {
+    test('it does nothing when children have different backgrounds', function() {
         $child1 = create_component_with_bg_color(['backgroundColor' => 'primary']);
         $child2 = create_component_with_bg_color(['backgroundColor' => 'secondary']);
         $child3 = create_component_with_bg_color(['backgroundColor' => 'accent']);
@@ -155,14 +219,13 @@ describe('Set background colour based on inner components', function() {
 
         $parent->simplify_all_background_colors();
 
-        $spy->shouldReceive('set_background_color_based_on_inner_components');
-        expect($parent->get_background_color())->toBeNull()
-            ->and($parent->innerComponents[0]->get_background_color())->toBe(ThemeColor::PRIMARY)
-            ->and($parent->innerComponents[1]->get_background_color())->toBe(ThemeColor::SECONDARY)
-            ->and($parent->innerComponents[2]->get_background_color())->toBe(ThemeColor::ACCENT);
+        expect($parent->get_background_colors())->toBeNull()
+            ->and($parent->innerComponents[0]->get_background_colors())->toBe(ThemeColor::PRIMARY)
+            ->and($parent->innerComponents[1]->get_background_colors())->toBe(ThemeColor::SECONDARY)
+            ->and($parent->innerComponents[2]->get_background_colors())->toBe(ThemeColor::ACCENT);
     });
 
-    test('it sets a background when the inner components have a mix of the same and no backgrounds set', function() use ($spy) {
+    test('it sets a background when the inner components have a mix of the same and no backgrounds set', function() {
         $child1 = create_component_with_bg_color(['backgroundColor' => 'primary']);
         $child2 = create_component_with_bg_color([]); // Null background
         $child3 = create_component_with_bg_color(['backgroundColor' => 'primary']);
@@ -174,14 +237,13 @@ describe('Set background colour based on inner components', function() {
 
         $parent->simplify_all_background_colors();
 
-        $spy->shouldReceive('set_background_color_based_on_inner_components');
-        expect($parent->get_background_color())->toBe(ThemeColor::PRIMARY)
-            ->and($parent->innerComponents[0]->get_background_color())->toBeNull()
-            ->and($parent->innerComponents[1]->get_background_color())->toBeNull()
-            ->and($parent->innerComponents[2]->get_background_color())->toBeNull();
+        expect($parent->get_background_colors())->toBe(ThemeColor::PRIMARY)
+            ->and($parent->innerComponents[0]->get_background_colors())->toBeNull()
+            ->and($parent->innerComponents[1]->get_background_colors())->toBeNull()
+            ->and($parent->innerComponents[2]->get_background_colors())->toBeNull();
     });
 
-    test('it does nothing if there is only one inner component', function() use ($spy) {
+    test('it does nothing if there is only one inner component', function() {
         $child = create_component_with_bg_color(['backgroundColor' => 'primary']);
         $parent = create_component_with_inner_components(
             [], // No background
@@ -190,8 +252,7 @@ describe('Set background colour based on inner components', function() {
 
         $parent->simplify_all_background_colors();
 
-        $spy->shouldNotHaveReceived('set_background_color_based_on_inner_components');
-        expect($parent->get_background_color())->toBeNull()
-            ->and($parent->innerComponents[0]->get_background_color())->toBe(ThemeColor::PRIMARY);
+        expect($parent->get_background_colors())->toBeNull()
+            ->and($parent->innerComponents[0]->get_background_colors())->toBe(ThemeColor::PRIMARY);
     });
-});
+ });

--- a/packages/core/src/base/types/BackgroundCollection.php
+++ b/packages/core/src/base/types/BackgroundCollection.php
@@ -1,0 +1,54 @@
+<?php
+namespace Doubleedesign\Comet\Core;
+
+class BackgroundCollection {
+    public private(set) ThemeColor|ThemeGradient|null $outer = null;
+    public private(set) ?ThemeColor $inner = null;
+
+    public function __construct($outer = null, $inner = null) {
+        $this->outer = self::validate_outer($outer);
+        $this->inner = self::validate_inner($inner);
+    }
+
+    private static function validate_outer($color): ThemeColor|ThemeGradient|null {
+        if ($color instanceof ThemeColor || $color instanceof ThemeGradient) {
+            return $color;
+        }
+
+        return ThemeColor::tryFrom($color) ?? ThemeGradient::tryFrom($color) ?? null;
+    }
+
+    private static function validate_inner($color): ?ThemeColor {
+        if ($color instanceof ThemeColor) {
+            return $color;
+        }
+
+        return ThemeColor::tryFrom($color) ?? null;
+    }
+
+    public static function transform_to_collection($value): ?BackgroundCollection {
+        if ($value instanceof BackgroundCollection) {
+            return $value;
+        }
+        // Backwards compatibility - handle single values
+        else if ($value instanceof ThemeColor || $value instanceof ThemeGradient || is_string($value)) {
+            return new BackgroundCollection($value);
+        }
+        // Also allow arrays, for simplicity in some implementations
+        else if (is_array($value)) {
+            $outer = $value['outer'] ?? $value[0] ?? null;
+            $inner = $value['inner'] ?? $value[1] ?? null;
+
+            $outer = self::validate_outer($outer);
+            $inner = self::validate_inner($inner);
+
+            if ($outer === null && $inner === null) {
+                return null;
+            }
+
+            return new BackgroundCollection($outer, $inner);
+        }
+
+        return null;
+    }
+}

--- a/packages/core/src/base/types/ThemeGradient.php
+++ b/packages/core/src/base/types/ThemeGradient.php
@@ -1,0 +1,53 @@
+<?php
+namespace Doubleedesign\Comet\Core;
+
+class ThemeGradient {
+    private ?ThemeColor $from;
+    private ?ThemeColor $to;
+
+    // Enable accessing the string value in the same way we do for the ThemeColor enum
+    public string $value {
+        get { return $this->__toString(); }
+    }
+
+    public function __construct(ThemeColor|string $from, ThemeColor|string $to) {
+        $this->from = self::value_to_themecolor($from);
+        $this->to = self::value_to_themecolor($to);
+    }
+
+    public static function tryFrom(?string $value): ?self {
+        if (!$value) {
+            return null;
+        }
+
+        $parts = explode('-', $value);
+        if (count($parts) !== 2) {
+            return null;
+        }
+
+        $from = self::value_to_themecolor($parts[0]);
+        $to = self::value_to_themecolor($parts[1]);
+
+        if (!$from || !$to) {
+            return null;
+        }
+
+        return new self($from, $to);
+    }
+
+    private static function value_to_themecolor(ThemeColor|string $color): ?ThemeColor {
+        if ($color instanceof ThemeColor) {
+            return $color;
+        }
+
+        return ThemeColor::tryFrom($color) ?? null;
+    }
+
+    public function __toString(): string {
+        if (!$this->from || !$this->to) {
+            return '';
+        }
+
+        return "{$this->from->value}-{$this->to->value}";
+    }
+}

--- a/packages/core/src/base/types/__tests__/BackgroundCollectionTest.php
+++ b/packages/core/src/base/types/__tests__/BackgroundCollectionTest.php
@@ -1,0 +1,179 @@
+<?php
+
+use Doubleedesign\Comet\Core\{BackgroundCollection, ThemeColor, ThemeGradient};
+
+describe('Standard instance creation', function() {
+    test('outer value is set if only one value is provided (string)', function() {
+        $instance = new BackgroundCollection('primary');
+
+        expect($instance->outer)->toBe(ThemeColor::PRIMARY)
+            ->and($instance->inner)->toBeNull();
+    });
+
+    test('outer value is set if only one value is provided (ThemeColor)', function() {
+        $instance = new BackgroundCollection(ThemeColor::SECONDARY);
+
+        expect($instance->outer)->toBe(ThemeColor::SECONDARY)
+            ->and($instance->inner)->toBeNull();
+    });
+
+    test('outer value is set if only one value is provided (ThemeGradient)', function() {
+        $instance = new BackgroundCollection(new ThemeGradient(ThemeColor::DARK, ThemeColor::LIGHT));
+
+        expect($instance->outer->value)->toBe('dark-light')
+            ->and($instance->inner)->toBeNull();
+    });
+
+    test('outer value is set if only one value is provided (gradient string)', function() {
+        $instance = new BackgroundCollection('accent-white');
+
+        expect($instance->outer->value)->toBe('accent-white')
+            ->and($instance->inner)->toBeNull();
+    });
+
+    test('invalid value provided for outer', function() {
+        $instance = new BackgroundCollection('#FFF');
+
+        expect($instance->outer)->toBeNull()
+            ->and($instance->inner)->toBeNull();
+    });
+
+    test('only inner value provided (string)', function() {
+        $instance = new BackgroundCollection(null, 'primary');
+
+        expect($instance->outer)->toBeNull()
+            ->and($instance->inner)->toBe(ThemeColor::PRIMARY);
+    });
+
+    test('only inner value provided (ThemeColor)', function() {
+        $instance = new BackgroundCollection(null, ThemeColor::SECONDARY);
+
+        expect($instance->outer)->toBeNull()
+            ->and($instance->inner)->toBe(ThemeColor::SECONDARY);
+    });
+
+    test('invalid string value provided for inner', function() {
+        $instance = new BackgroundCollection(null, '#FFF');
+
+        expect($instance->outer)->toBeNull()
+            ->and($instance->inner)->toBeNull();
+    });
+
+    test('inner cannot be a gradient (string provided)', function() {
+        $instance = new BackgroundCollection(null, 'primary-to-secondary');
+
+        expect($instance->outer)->toBeNull()
+            ->and($instance->inner)->toBeNull();
+    });
+
+    test('inner cannot be a gradient (object provided)', function() {
+        $instance = new BackgroundCollection(null, new ThemeGradient(ThemeColor::PRIMARY, ThemeColor::SECONDARY));
+
+        expect($instance->outer)->toBeNull()
+            ->and($instance->inner)->toBeNull();
+    });
+
+    it('returns ThemeColors for both values when two valid string values provided', function() {
+        $instance = new BackgroundCollection('primary', 'secondary');
+
+        expect($instance->outer)->toBe(ThemeColor::PRIMARY)
+            ->and($instance->inner)->toBe(ThemeColor::SECONDARY);
+    });
+
+    it('returns null for both values when two invalid string values provided', function() {
+        $instance = new BackgroundCollection('#FFF', '#000');
+
+        expect($instance->outer)->toBeNull()
+            ->and($instance->inner)->toBeNull();
+    });
+
+    test('valid outer, invalid inner', function() {
+        $instance = new BackgroundCollection('primary', '#000');
+
+        expect($instance->outer)->toBe(ThemeColor::PRIMARY)
+            ->and($instance->inner)->toBeNull();
+    });
+
+    test('invalid outer, valid inner', function() {
+        $instance = new BackgroundCollection('#FFF', 'secondary');
+
+        expect($instance->outer)->toBeNull()
+            ->and($instance->inner)->toBe(ThemeColor::SECONDARY);
+    });
+
+    test('cannot set outer property directly', function() {
+        $instance = new BackgroundCollection();
+
+        expect(fn() => $instance->outer = ThemeColor::PRIMARY)->toThrow(\Error::class);
+    });
+
+    test('cannot set inner property directly', function() {
+        $instance = new BackgroundCollection();
+
+        expect(fn() => $instance->inner = ThemeColor::PRIMARY)->toThrow(\Error::class);
+    });
+});
+
+describe('creation from a range of formats using transform_to_collection', function() {
+    it('creates a BackgroundCollection object from a pair of colours', function($input) {
+        $collection = BackgroundCollection::transform_to_collection($input);
+
+        expect($collection)->toBeInstanceOf(BackgroundCollection::class);
+    })->with('colour pairs');
+
+    it('sets the correct values from a pair of colours', function($input) {
+        $collection = BackgroundCollection::transform_to_collection($input);
+
+        expect($collection->outer)->toBe(ThemeColor::DARK)
+            ->and($collection->inner)->toBe(ThemeColor::LIGHT);
+    })->with('colour pairs');
+
+    it('creates a BackgroundCollection object from a gradient + a colour', function($input) {
+        $collection = BackgroundCollection::transform_to_collection($input);
+
+        expect($collection)->toBeInstanceOf(BackgroundCollection::class);
+    })->with('gradient + colour');
+
+    it('sets the correct values from a gradient + a colour', function($input) {
+        $collection = BackgroundCollection::transform_to_collection($input);
+
+        expect($collection->outer->value)->toBe('dark-light')
+            ->and($collection->inner)->toBe(ThemeColor::PRIMARY);
+    })->with('gradient + colour');
+
+    it('returns null for both values if invalid input is provided for a single value', function($input) {
+        $collection = BackgroundCollection::transform_to_collection($input);
+
+        expect($collection->outer)->toBeNull()
+            ->and($collection->inner)->toBeNull();
+    })->with('invalid inputs');
+
+    it('returns a valid outer value + null inner value if a valid outer value and invalid inner value are provided', function() {
+        $collection = BackgroundCollection::transform_to_collection(['outer' => 'primary', 'inner' => '#000']);
+
+        expect($collection->outer)->toBe(ThemeColor::PRIMARY)
+            ->and($collection->inner)->toBeNull();
+    });
+});
+
+dataset('colour pairs', [
+    'BackgroundCollection object'                                 => new BackgroundCollection(ThemeColor::DARK, ThemeColor::LIGHT),
+    'indexed array of colours'                                    => [['dark', 'light']],
+    'associative array of colours in order (strings)'             => [['outer' => 'dark', 'inner' => 'light']],
+    'associative array of colours in order (objects)'             => [['outer' => ThemeColor::DARK, 'inner' => ThemeColor::LIGHT]],
+    'associative array of colours out of order (strings)'         => [['inner' => 'light', 'outer' => 'dark']],
+    'associative array of colours out of order (objects)'         => [['inner' => ThemeColor::LIGHT, 'outer' => ThemeColor::DARK]],
+]);
+
+dataset('gradient + colour', [
+    'BackgroundCollection object' 		                    => new BackgroundCollection(new ThemeGradient('dark', 'light'), ThemeColor::PRIMARY),
+    'indexed array with a gradient string'              => [['dark-light', 'primary']],
+    'indexed array with a gradient object'              => [[new ThemeGradient('dark', 'light'), ThemeColor::PRIMARY]],
+]);
+
+dataset('invalid inputs', [
+    'invalid string'                    => 'not-a-valid-colour',
+    'integer'                           => 123,
+    'object of wrong type'              => (object)['color' => 'invalid'],
+    'array of wrong format'             => [['outer' => 'invalid']],
+]);

--- a/packages/core/src/base/types/__tests__/ThemeGradientTest.php
+++ b/packages/core/src/base/types/__tests__/ThemeGradientTest.php
@@ -1,0 +1,44 @@
+<?php
+use Doubleedesign\Comet\Core\{ThemeGradient,ThemeColor};
+
+test('two valid ThemeColor values', function() {
+    $instance = new ThemeGradient(ThemeColor::LIGHT, ThemeColor::DARK);
+
+    expect($instance)->toEqual('light-dark');
+});
+
+test('two valid string values', function() {
+    $instance = new ThemeGradient('primary', 'secondary');
+
+    expect($instance)->toEqual('primary-secondary');
+});
+
+it('returns empty if a valid string from value is provided with an invalid to value', function() {
+    $instance = new ThemeGradient('primary', 'invalid');
+
+    expect($instance)->toEqual('');
+});
+
+it('returns empty if a valid ThemeColor from value is provided with an invalid to value', function() {
+    $instance = new ThemeGradient(ThemeColor::ACCENT, 'invalid');
+
+    expect($instance)->toEqual('');
+});
+
+it('returns empty if an invalid from value is provided with a valid string to value', function() {
+    $instance = new ThemeGradient('invalid', 'secondary');
+
+    expect($instance)->toEqual('');
+});
+
+it('returns empty if an invalid from value is provided with a valid ThemeColor to value', function() {
+    $instance = new ThemeGradient('invalid', ThemeColor::LIGHT);
+
+    expect($instance)->toEqual('');
+});
+
+it('returns empty if two invalid strings are provided', function() {
+    $instance = new ThemeGradient('invalid', 'invalid');
+
+    expect($instance)->toEqual('');
+});

--- a/packages/core/src/components/Card/Card.php
+++ b/packages/core/src/components/Card/Card.php
@@ -63,7 +63,7 @@ class Card extends UIComponent {
         $this->withWrapper = $attributes['withWrapper'] ?? $this->withWrapper;
         $this->set_is_nested($attributes['isNested'] ?? true);
         $this->set_color_theme($attributes);
-        $this->set_background_color($attributes);
+        $this->set_background_colors($attributes);
         $this->set_orientation($attributes);
 
         $innerComponents = $this->aboveContentComponents ?? [];

--- a/packages/core/src/components/Group/Group.php
+++ b/packages/core/src/components/Group/Group.php
@@ -33,7 +33,7 @@ class Group extends UIComponent {
         $this->set_color_theme($attributes);
         /* Allow groups without a specified background to be transparent rather than defaulting to the fallback */
         if (isset($attributes['backgroundColor'])) {
-            $this->set_background_color($attributes);
+            $this->set_background_colors($attributes);
             $this->simplify_all_background_colors();
         }
 

--- a/packages/core/src/components/PageSection/PageSection.php
+++ b/packages/core/src/components/PageSection/PageSection.php
@@ -26,7 +26,7 @@ class PageSection extends Renderable {
     public function __construct(array $attributes, array $innerComponents) {
         parent::__construct($attributes, 'components.PageSection.page-section');
         $this->set_shortname($attributes['shortName'] ?? 'page-section');
-        $this->set_background_color($attributes);
+        $this->set_background_colors($attributes);
         $this->set_color_theme($attributes);
         $this->innerComponents = $innerComponents;
     }

--- a/packages/core/src/components/SiteHeader/SiteHeader.php
+++ b/packages/core/src/components/SiteHeader/SiteHeader.php
@@ -88,7 +88,7 @@ class SiteHeader extends UIComponent {
         parent::__construct($attributes, $innerComponents, 'components.SiteHeader.site-header');
 
         $this->set_size($attributes);
-        $this->set_background_color($attributes);
+        $this->set_background_colors($attributes);
         $this->set_overlay_background_color_from_attrs($attributes);
         $this->set_icon_from_attrs($attributes);
         $this->breakpoint = $attributes['breakpoint'] ?? $this->breakpoint;

--- a/packages/core/src/components/Table/TableCell/TableCell.php
+++ b/packages/core/src/components/Table/TableCell/TableCell.php
@@ -22,7 +22,7 @@ class TableCell extends TextElement {
         );
         $this->innerComponents = gettype($content) === 'string' ? [] : [$content];
         $this->set_text_align_from_attrs($attributes);
-        $this->set_background_color($attributes);
+        $this->set_background_colors($attributes);
         $this->verticalAlign = $attributes['verticalAlign'] ?? null;
     }
 


### PR DESCRIPTION
- Add gradient class.
- Update background colour trait to support dual backgrounds, including gradients for the outer backgrounds
- Ensure backwards compatibility - if a single value is provided to set the background, use it as the outer background; also return the outer background (or inner if it is set and outer is null) for `get_background_color`. 

This change does not yet implement the dual backgrounds in the rendered HTML. This is to be done in https://github.com/doubleedesign/comet-components/issues/9.